### PR TITLE
Typos in how to use the task section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ mix insert_license --license mit
 $ mix insert_license --verify --license mit
 ```
 
-Here, the `--license` option takes one of these values `mit,agpl, gpl, lgpl, mozilla, apache, boost`
+Here, the `--license` option takes one of these values `mit, agpl, gpl, lgpl, mozilla, apache, boost`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@ Utility to insert license header in each Elixir file using SPDX specification.
 
 A mix task is available to insert header or to verify (useful for CI actions)
 
-
 ```
-$ mix insert_license --licence mit
-```
-
-```
-mix insert_licence --verify --license mit
+$ mix insert_license --license mit
 ```
 
+```
+mix insert_license --verify --license mit
+```
 
 ## Installation
 
-If [available in Hex](https://hex.pm/ex_license), the package can be installed
+Install from [Hex](https://hex.pm/ex_license), the package can be installed
 by adding `ex_license` to your list of dependencies in `mix.exs`:
 
 ```elixir
@@ -27,7 +25,18 @@ def deps do
 end
 ```
 
+## Available License
+
+It supports the following license
+
+- [x] mit
+- [x] agpl_v3
+- [x] gpl_v3
+- [x] lgpl_v3
+- [x] mozilla_v2
+- [x] apache_v2
+- [x] boost_v1
+
 Documentation can be generated with [ExDoc](https://github.com/samuelmanzanera/ex_license)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/ex_license](https://hexdocs.pm/ex_license).
-

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Utility to insert license header in each Elixir file using SPDX specification.
 
 A mix task is available to insert header or to verify (useful for CI actions)
 
-```
+```sh
 $ mix insert_license --license mit
 ```
 
+```sh
+$ mix insert_license --verify --license mit
 ```
-mix insert_license --verify --license mit
-```
+
+Here, the `--license` option takes one of these values `mit,agpl, gpl, lgpl, mozilla, apache, boost`
 
 ## Installation
 
@@ -29,13 +31,13 @@ end
 
 It supports the following license
 
-- [x] mit
-- [x] agpl_v3
-- [x] gpl_v3
-- [x] lgpl_v3
-- [x] mozilla_v2
-- [x] apache_v2
-- [x] boost_v1
+- [x] [mit](https://spdx.org/licenses/MIT.html)
+- [x] [agpl_v3](https://spdx.org/licenses/AGPL-3.0-or-later.html)
+- [x] [gpl_v3](https://spdx.org/licenses/GPL-3.0-or-later.html)
+- [x] [lgpl_v3](https://spdx.org/licenses/LGPL-3.0-or-later.html)
+- [x] [mozilla_v2](https://spdx.org/licenses/MPL-2.0.html)
+- [x] [apache_v2](https://spdx.org/licenses/Apache-2.0.html)
+- [x] [boost_v1](https://spdx.org/licenses/BSL-1.0.html)
 
 Documentation can be generated with [ExDoc](https://github.com/samuelmanzanera/ex_license)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can

--- a/lib/mix/tasks/insert_license.ex
+++ b/lib/mix/tasks/insert_license.ex
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.InsertLicense do
         case cast(String.upcase(license)) do
           {:ok, license} ->
             verify(license)
+
           :error ->
             Mix.shell().error("you pass an invalid license")
             Mix.shell().info("you should pass 'mit,agpl, gpl, lgpl, mozilla, apache, boost'")
@@ -18,17 +19,18 @@ defmodule Mix.Tasks.InsertLicense do
         case cast(String.upcase(license)) do
           {:ok, license} ->
             insert(license)
+
           :error ->
             Mix.shell().error("you pass an invalid license")
             Mix.shell().info("you should pass 'mit,agpl, gpl, lgpl, mozilla, apache, boost'")
-
         end
-      
+
       _ ->
-        Mix.shell().info("You have to pass --license flag and --verify if you can check all the files")
+        Mix.shell().info(
+          "You have to pass --license flag and --verify if you can check all the files"
+        )
     end
   end
-
 
   defp cast("MIT"), do: {:ok, :mit}
   defp cast("AGPL"), do: {:ok, :agpl_v3}


### PR DESCRIPTION
A couple of typos in generating license header and verifying.